### PR TITLE
Clarify Azure SQL resource selection in Lab 1 and Lab 2 instructions

### DIFF
--- a/Instructions/Labs/01-provision-sql-vm.md
+++ b/Instructions/Labs/01-provision-sql-vm.md
@@ -24,7 +24,7 @@ You are a database administrator for AdventureWorks. You need to create a test e
 
 1. Locate the search bar at the top of the page. Search for **Azure SQL**. Select the search result for **Azure SQL** that appears in the results under **Services**.
 
-1. On the **Azure SQL** blade, select **Create**.
+1. On the side bar, expand the **SQL server** and select the **SQL server on Azure VMs**, then select **Create**.
 
 1. On the **Select SQL deployment option** blade, click on the drop-down box under **SQL virtual machines**. Select the option labeled **Free SQL Server License: SQL Server 2022 Developer on Windows Server 2022**. Then select **Create**.
 

--- a/Instructions/Labs/02-provision-sql-database.md
+++ b/Instructions/Labs/02-provision-sql-database.md
@@ -45,9 +45,9 @@ As a database administrator for AdventureWorks, you will set up a new SQL Databa
 
 ## Provision an Azure SQL Database in the Azure portal
 
-1. From the Azure Portal, search for *SQL databases* in the search box at the top, then select **SQL databases** from the list of options.
+1. From the Azure Portal, search for *SQL databases* in the search box at the top, then select **Azure SQL databases** from the list of services.
 
-1. On the **SQL databases** blade, select **+ Create**.
+1. On the **Azure SQL databases** page, select **+ Create**.
 
 1. On the **Create SQL Database** page, select the following options on the **Basics** tab and then select **Next: Networking**.
 
@@ -66,7 +66,7 @@ As a database administrator for AdventureWorks, you will set up a new SQL Databa
     - **Workload environment:** Development
     - On the **Compute + Storage** option, select on **Configure database** link. On the **Configure** page, for **Service tier** dropdown, select **Basic**, and then **Apply**.
 
-1. For the **Backup storage redundancy** option, keep the default value: **Local-redundant backup storage**.
+1. For the **Backup storage redundancy** option, keep the default value: **Locally-redundant backup storage**.
 
 1. Then select **Next: Networking**.
 
@@ -117,7 +117,7 @@ As a database administrator for AdventureWorks, you will set up a new SQL Databa
 
 ## Connect to an Azure SQL Database in SQL Server Management Studio
 
-1. On the Azure portal, select the **SQL databases** in the left navigation pane. And then select the **AdventureWorksLT** database.
+1. On the Azure portal, select the **SQL database** resource. And then select the **AdventureWorksLT** database.
 
 1. Copy the **Server name** value from the **Overview** page.
 


### PR DESCRIPTION
This pull request updates lab instructions for provisioning SQL resources in Azure to improve clarity and accuracy. The main changes involve refining navigation steps and correcting terminology to match the current Azure Portal UI.

**Instruction navigation and terminology updates:**

* In `01-provision-sql-vm.md`, updated the navigation steps to expand **SQL server** and select **SQL server on Azure VMs** before creating a VM, reflecting the latest Azure Portal workflow.
* In `02-provision-sql-database.md`, changed references from **SQL databases** to **Azure SQL databases** for consistency with the portal’s service naming.
* In `02-provision-sql-database.md`, corrected the backup storage redundancy option from **Local-redundant backup storage** to **Locally-redundant backup storage** to match the actual option in the portal.
* In `02-provision-sql-database.md`, clarified instructions to select the **SQL database** resource instead of **SQL databases** when connecting in SSMS, for improved accuracy.